### PR TITLE
fixed reference issue

### DIFF
--- a/generatecertificate.sh
+++ b/generatecertificate.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout ./localtest.me.key -out ./localtest.me.crt -config ./openssl.cnf
+openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout ./certs/localtest.me.key -out ./certs/localtest.me.crt -config ./openssl.cnf


### PR DESCRIPTION
When the file was moved up a level, the certs need to be moved to the /certs directory for the docker-compose volume reference.